### PR TITLE
drop links to Jitsi Meet changelogs

### DIFF
--- a/CHANGELOG-WEB.md
+++ b/CHANGELOG-WEB.md
@@ -1,16 +1,12 @@
 # Web Changelog
 
+Full changelogs are available in each project's release page: click on one of the releases below, click on Assets and there's the CHANGELOG. 
+
 ## 1.0.3992 (2020-04-10), 4416 (?), 1.0-544
 
 - [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4416)
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4416)
 - [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/download/stable%2Fjitsi-meet_4416/jitsi-videobridge__CHANGELOG.txt)
-
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_4416/jitsi-meet_1.0.3992_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.
 
 
 ## 1.0.3969 (2020-04-03), 2.1-164, 1.0-541
@@ -19,24 +15,12 @@ Full changelogs are available in each project's release page.
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4384)
 - [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4376)
 
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_4384/jitsi-meet_1.0.3969_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.
-
 
 ## 1.0.3962 (2020-04-02), 2.1-163, 1.0-541
 
 - [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4376)
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4376)
 - [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4376)
-
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_4376/jitsi-meet_1.0.3962_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.
 
 
 ## 1.0.3928 (2020-04-01), 2.1-157, 1.0-539
@@ -45,12 +29,6 @@ Full changelogs are available in each project's release page.
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4335)
 - [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4335)
 
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_4335/jitsi-meet_1.0.3928_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.
-
 
 ## 4101 (2019-11-26)
 
@@ -58,11 +36,6 @@ Full changelogs are available in each project's release page.
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable/jitsi-meet_4101)
 - [Jitsi Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable/jitsi-meet_4101)
 
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_4101/jitsi-meet_3729_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.
 
 ## 3936 (2019-08-20)
 
@@ -70,20 +43,9 @@ Full changelogs are available in each project's release page.
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable/jitsi-meet_3936)
 - [Jitsi Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable/jitsi-meet_3936)
 
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_3936/jitsi-meet_3577_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.
 
 ## 3734 (2019-05-10)
 
 - [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable/jitsi-meet_3734)
 - [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable/jitsi-meet_3734)
 - [Jitsi Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable/jitsi-meet_3734)
-
-### Changes
-
-- https://github.com/jitsi/jitsi-meet/releases/download/stable%2Fjitsi-meet_3734/jitsi-meet_3387_CHANGELOG.txt
-
-Full changelogs are available in each project's release page.


### PR DESCRIPTION
Individual CHANGELOGs are easily reachable via the release pages. Until someone is eager to do the additional work of copying the links out and inserting them here I suggest to drop the direct CHANGELOG links.

This branch is based on my `patch-1` branch