### PR TITLE
move version numbers into link text

### DIFF
--- a/CHANGELOG-WEB.md
+++ b/CHANGELOG-WEB.md
@@ -2,32 +2,32 @@
 
 Full changelogs are available in each project's release page: click on one of the releases below, click on Assets and there's the CHANGELOG. 
 
-## 1.0.3992 (2020-04-10), 4416 (?), 1.0-544
+##  2020-04-10
 
-- [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4416)
-- [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4416)
-- [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/download/stable%2Fjitsi-meet_4416/jitsi-videobridge__CHANGELOG.txt)
-
-
-## 1.0.3969 (2020-04-03), 2.1-164, 1.0-541
-
-- [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4384)
-- [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4384)
-- [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4376)
+- [Jitsi Meet 1.0.3992](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4416)
+- [Jicofo 1.0-544](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4416)
+- [Jitis Videobridge 4416 (?),](https://github.com/jitsi/jitsi-videobridge/releases/download/stable%2Fjitsi-meet_4416/jitsi-videobridge__CHANGELOG.txt)
 
 
-## 1.0.3962 (2020-04-02), 2.1-163, 1.0-541
+## 2020-04-03
 
-- [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4376)
-- [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4376)
-- [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4376)
+- [Jitsi Meet 1.0.3969](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4384)
+- [Jicofo 1.0-541](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4384)
+- [Jitis Videobridge 2.1-164](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4376)
 
 
-## 1.0.3928 (2020-04-01), 2.1-157, 1.0-539
+## 2020-04-02
 
-- [Jitsi Meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4335)
-- [Jicofo](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4335)
-- [Jitis Videobridge](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4335)
+- [Jitsi Meet 1.0.3962](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4376)
+- [Jicofo 1.0-541](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4376)
+- [Jitis Videobridge 2.1-163](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4376)
+
+
+## 2020-04-01
+
+- [Jitsi Meet 1.0.3928](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_4335)
+- [Jicofo 1.0-539](https://github.com/jitsi/jicofo/releases/tag/stable%2Fjitsi-meet_4335)
+- [Jitis Videobridge 2.1-157](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_4335)
 
 
 ## 4101 (2019-11-26)


### PR DESCRIPTION
Since the 2020-04-01 release Jitsi Meet, Jicofo and the Videobridge are versioned individually. Keep only the release date in the release title and move individual release version next to the product name.